### PR TITLE
Fix/137 프론트 연결 관련

### DIFF
--- a/src/main/java/com/travel/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/travel/domain/itinerary/dto/ItineraryResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class ItineraryResponse {
     private Long itineraryId;
     private LocalDate tourDate;
+    private String dailyTourPlace;
     private List<SimplePlaceDto> places;
 }
 

--- a/src/main/java/com/travel/domain/itinerary/dto/ItinerarySaveRequest.java
+++ b/src/main/java/com/travel/domain/itinerary/dto/ItinerarySaveRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 public class ItinerarySaveRequest {
     private LocalDate tourDate;
-
+    private String dailyTourPlace;
     private Long tripId;
     private Long memberId;
 

--- a/src/main/java/com/travel/domain/itinerary/dto/ItinerarySaveResponse.java
+++ b/src/main/java/com/travel/domain/itinerary/dto/ItinerarySaveResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 public class ItinerarySaveResponse {
     private Long itineraryId;
+    private String dailyTourPlace;
     private LocalDate tourDate;
     private List<SimplePlaceDto> places;
 

--- a/src/main/java/com/travel/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/travel/domain/itinerary/entity/Itinerary.java
@@ -35,6 +35,9 @@ public class Itinerary extends BaseTimeEntity {
     @Column(name = "tour_date")
     private LocalDate tourDate;
 
+    @Column(name = "DailyTourPlace")
+    private String dailyTourPlace;
+
     //note 사용하지 않을 듯 해서 지웠습니다.
     //@Column(name = "note", length = 1000)
     //private String note;

--- a/src/main/java/com/travel/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/travel/domain/itinerary/service/ItineraryService.java
@@ -74,7 +74,7 @@ public class ItineraryService {
                         .orElseGet(() -> {
                             MyPlace myPlace_ = MyPlace.builder()
                                     .placeGoogleId(simplePlace.getPlaceGoogleId())
-                                    .category(Category.MY_PLACE)
+                                    .category(simplePlace.getCategory())
                                     .name(simplePlace.getName())
                                     .lat(simplePlace.getLat())
                                     .lng(simplePlace.getLng())

--- a/src/main/java/com/travel/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/travel/domain/itinerary/service/ItineraryService.java
@@ -18,10 +18,12 @@ import com.travel.domain.trip.dao.TripRepository;
 import com.travel.domain.trip.entity.Trip;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ItineraryService {
@@ -48,12 +50,14 @@ public class ItineraryService {
                 .trip(trip)
                 .member(member)
                 .tourDate(itinerarySaveRequest.getTourDate())
+                .dailyTourPlace(itinerarySaveRequest.getDailyTourPlace())
                 .places(places)
                 .myPlaces(myPlaces)
                 .itineraryPlaceTypeOrder(itineraryPlaceTypeOrder)
                 .build();
 
         itineraryRepository.save(itinerary);
+        log.info("itinerary {} saved", itinerarySaveRequest.getTourDate());
 
         return ItinerarySaveResponse.builder()
                 .itineraryId(itinerary.getId())

--- a/src/main/java/com/travel/domain/place/dto/RecommendationRequest.java
+++ b/src/main/java/com/travel/domain/place/dto/RecommendationRequest.java
@@ -7,19 +7,19 @@ import com.travel.domain.placetype.entity.restaurant.RestaurantType;
 import com.travel.domain.placetype.entity.tourattraction.SubjectiveTag;
 import com.travel.domain.placetype.entity.tourattraction.TourattractionTag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class RecommendationRequest {
-    /*
-    뭐가 필요할까
-    날짜... 지역 키워드, 테그 명칭들(관광지, 카페, )
-     */
+
     private String mainTourPlace;
 
+    @Schema(hidden = true)
     private int radius;
+
     private List<TourattractionTag> tourattractionTagList;
     private List<SubjectiveTag> subjectiveTagList;
     private List<RestaurantType> restaurantTypeList;

--- a/src/main/java/com/travel/domain/place/service/PlaceGoogleService.java
+++ b/src/main/java/com/travel/domain/place/service/PlaceGoogleService.java
@@ -111,8 +111,13 @@ public class PlaceGoogleService {
                 name = (String) result.get("name");
             }
 
-            Place place =
-                    Place.builder().placeGoogleId(placeId).name(name).lat(lat).lng(lng).build();
+            Place place = Place.builder()
+                    .placeGoogleId(placeId)
+                    .name(name)
+                    .lat(lat)
+                    .lng(lng)
+                    .category(Category.MY_PLACE)
+                    .build();
 
             placeList.add(place);
         }

--- a/src/main/java/com/travel/domain/place/service/PlaceGoogleService.java
+++ b/src/main/java/com/travel/domain/place/service/PlaceGoogleService.java
@@ -130,7 +130,7 @@ public class PlaceGoogleService {
                             .build(false)
                             .encode(StandardCharsets.UTF_8)
                             .toUri();
-            log.info("mainPlace 주소 변환 오류:  {}", uri);
+            log.info("mainPlace 주소로 좌표 획득 url:  {}", uri);
 
             Map<String, Object> apiResponse =
                     WebClient.create().get().uri(uri).retrieve().bodyToMono(Map.class).block();

--- a/src/main/java/com/travel/domain/trip/api/TripController.java
+++ b/src/main/java/com/travel/domain/trip/api/TripController.java
@@ -4,6 +4,7 @@ import com.travel.domain.itinerary.dao.ItineraryRepository;
 import com.travel.domain.itinerary.dto.SimplePlaceDto;
 import com.travel.domain.itinerary.service.ItineraryService;
 import com.travel.domain.trip.dto.request.TripSaveRequest;
+import com.travel.domain.trip.dto.response.SimpleTripResponse;
 import com.travel.domain.trip.dto.response.TripGetResponse;
 import com.travel.domain.trip.dto.response.TripSaveResponse;
 import com.travel.domain.trip.entity.Trip;
@@ -32,10 +33,10 @@ public class TripController {
     }
 
 
-    @Operation(summary = "MemberId로 특정 사용자의 전체 TripIdList 획득. 이후 getTrip API로 단일 Trip조회")
+    @Operation(summary = "MemberId로 특정 사용자의 전체 TripList를 조회. 간단한 정보만 반환하고 세부정보는 getTrip 사용")
     @GetMapping("/{memberId}")
-    public ResponseEntity<List<Long>> getTripIdListByMemberId(@PathVariable Long memberId) {
-        return ResponseEntity.ok(tripService.getTripIdListByMemberId(memberId));
+    public ResponseEntity<List<SimpleTripResponse>> getSimpleTripListByMemberId(@PathVariable Long memberId) {
+        return ResponseEntity.ok(tripService.getSimpleTripListByMemberId(memberId));
     }
 
     @Operation(summary = "TripId와 MemberId로 단일 Trip 정보 get")

--- a/src/main/java/com/travel/domain/trip/api/TripController.java
+++ b/src/main/java/com/travel/domain/trip/api/TripController.java
@@ -8,6 +8,7 @@ import com.travel.domain.trip.dto.response.TripGetResponse;
 import com.travel.domain.trip.dto.response.TripSaveResponse;
 import com.travel.domain.trip.entity.Trip;
 import com.travel.domain.trip.service.TripService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,15 +25,24 @@ public class TripController {
     private final TripService tripService;
     private final ItineraryService itineraryService;
 
+    @Operation(summary = "Trip 저장 API")
     @PostMapping("/save")
     public ResponseEntity<TripSaveResponse> saveTrip(@RequestBody TripSaveRequest request) {
         return ResponseEntity.ok(tripService.saveTrip(request));
     }
 
-    @GetMapping("/{tripId}")
+
+    @Operation(summary = "MemberId로 특정 사용자의 전체 TripIdList 획득. 이후 getTrip API로 단일 Trip조회")
+    @GetMapping("/{memberId}")
+    public ResponseEntity<List<Long>> getTripIdListByMemberId(@PathVariable Long memberId) {
+        return ResponseEntity.ok(tripService.getTripIdListByMemberId(memberId));
+    }
+
+    @Operation(summary = "TripId와 MemberId로 단일 Trip 정보 get")
+    @GetMapping("/{memberId}/{tripId}")
     public ResponseEntity<TripGetResponse> getTrip(
             @PathVariable Long tripId,
-            @RequestParam Long memberId) {
+            @PathVariable Long memberId) {
         return ResponseEntity.ok(tripService.getTripGetResponse(tripId, memberId));
     }
 

--- a/src/main/java/com/travel/domain/trip/dao/TripRepository.java
+++ b/src/main/java/com/travel/domain/trip/dao/TripRepository.java
@@ -16,6 +16,8 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
 
     List<Trip> findByMember(Member member);
 
+    List<Trip> findByMemberId(Long memberId);
+
     default Trip findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new CustomException(ErrorCode.TRIP_NOT_FOUND));
     }

--- a/src/main/java/com/travel/domain/trip/dto/request/TripSaveRequest.java
+++ b/src/main/java/com/travel/domain/trip/dto/request/TripSaveRequest.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class TripSaveRequest {
     private Long memberId;
     private String title;
-    private String mainTourPlace;
+    private List<String> mainTourPlace;
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean isPublic;

--- a/src/main/java/com/travel/domain/trip/dto/response/SimpleTripResponse.java
+++ b/src/main/java/com/travel/domain/trip/dto/response/SimpleTripResponse.java
@@ -1,0 +1,16 @@
+package com.travel.domain.trip.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class SimpleTripResponse {
+    private Long tripId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+}

--- a/src/main/java/com/travel/domain/trip/dto/response/TripGetResponse.java
+++ b/src/main/java/com/travel/domain/trip/dto/response/TripGetResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class TripGetResponse {
     private Long tripId;
     private String title;
-    private String mainTourPlace;
+    private List<String> mainTourPlace;
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean isPublic;

--- a/src/main/java/com/travel/domain/trip/dto/response/TripResponse.java
+++ b/src/main/java/com/travel/domain/trip/dto/response/TripResponse.java
@@ -1,6 +1,7 @@
 package com.travel.domain.trip.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.travel.domain.trip.entity.Trip;
 
@@ -15,7 +16,7 @@ public class TripResponse {
     private Long tripId;
 
     private String title;
-    private String mainTourPlace;
+    private List<String> mainTourPlace;
 
     private LocalDate startDate;
 

--- a/src/main/java/com/travel/domain/trip/dto/response/TripSaveResponse.java
+++ b/src/main/java/com/travel/domain/trip/dto/response/TripSaveResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class TripSaveResponse {
     private Long tripId;
     private String title;
-    private String mainTourPlace;
+    private List<String> mainTourPlace;
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean isPublic;

--- a/src/main/java/com/travel/domain/trip/entity/Trip.java
+++ b/src/main/java/com/travel/domain/trip/entity/Trip.java
@@ -35,8 +35,11 @@ public class Trip extends BaseTimeEntity {
     private String title;
 
 
-    @Column(name = "mainTourPlace", length = 100)
-    private String mainTourPlace;
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(name = "trip_main_tour_place", joinColumns = @JoinColumn(name = "trip_id"))
+    @Column(name = "main_tour_place")
+    private List<String> mainTourPlace = new ArrayList<>();
 
     @Column(name = "start_date")
     private LocalDate startDate;

--- a/src/main/java/com/travel/domain/trip/service/TripService.java
+++ b/src/main/java/com/travel/domain/trip/service/TripService.java
@@ -6,9 +6,11 @@ import com.travel.domain.itinerary.service.ItineraryService;
 import com.travel.domain.member.dao.MemberRepository;
 
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.travel.domain.trip.dto.response.SimpleTripResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -111,8 +113,17 @@ public class TripService {
         return tripRepository.findByIdOrElseThrow(tripId);
     }
 
-    public List<Long> getTripIdListByMemberId(Long memberId) {
+    public List<SimpleTripResponse> getSimpleTripListByMemberId(Long memberId) {
         List<Trip> tripList = tripRepository.findByMemberId(memberId);
-        return tripList.stream().map(Trip::getId).collect(Collectors.toList());
+        List<SimpleTripResponse> simpleTripResponseList= new ArrayList<>();
+        for(Trip trip : tripList) {
+            simpleTripResponseList.add(SimpleTripResponse.builder()
+                    .tripId(trip.getId())
+                    .title(trip.getTitle())
+                    .startDate(trip.getStartDate())
+                    .endDate(trip.getEndDate())
+                    .build());
+        }
+        return simpleTripResponseList;
     }
 }

--- a/src/main/java/com/travel/domain/trip/service/TripService.java
+++ b/src/main/java/com/travel/domain/trip/service/TripService.java
@@ -9,6 +9,7 @@ import com.travel.domain.member.dao.MemberRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 
@@ -22,6 +23,7 @@ import com.travel.domain.trip.entity.Trip;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TripService {
@@ -47,13 +49,15 @@ public class TripService {
         for (int i = 0; i < request.getListOfPlaces().size(); i++) {
             List<SimplePlaceDto> dailyPlaceList = request.getListOfPlaces().get(i);
 
-            ItinerarySaveRequest itineraryRequest = new ItinerarySaveRequest();
-            itineraryRequest.setTripId(trip.getId());
-            itineraryRequest.setMemberId(member.getId());
-            itineraryRequest.setTourDate(request.getStartDate().plusDays(i));
-            itineraryRequest.setPlaces(dailyPlaceList);
+            ItinerarySaveRequest itinerarySaveRequest = new ItinerarySaveRequest();
+            itinerarySaveRequest.setTripId(trip.getId());
+            itinerarySaveRequest.setMemberId(member.getId());
+            itinerarySaveRequest.setTourDate(request.getStartDate().plusDays(i));
+            itinerarySaveRequest.setPlaces(dailyPlaceList);
+            itinerarySaveRequest.setDailyTourPlace(request.getMainTourPlace().get(i));
 
-            itineraryService.saveItinerary(itineraryRequest);
+            itineraryService.saveItinerary(itinerarySaveRequest);
+            log.info("itinerary {} save request send", request.getStartDate().plusDays(i));
         }
 
         return TripSaveResponse.builder()

--- a/src/main/java/com/travel/domain/trip/service/TripService.java
+++ b/src/main/java/com/travel/domain/trip/service/TripService.java
@@ -106,4 +106,9 @@ public class TripService {
 
         return tripRepository.findByIdOrElseThrow(tripId);
     }
+
+    public List<Long> getTripIdListByMemberId(Long memberId) {
+        List<Trip> tripList = tripRepository.findByMemberId(memberId);
+        return tripList.stream().map(Trip::getId).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
🌱 관련 이슈  
close #137 

## 📌 작업 내용  
- 일일 핵심 방문지 추가(Trip의 MainTourPlace를 하나가 아닌, 일별로 여러개 받음)
- memberId로 해당 사용자의 Trip 전체 조회 API(simple한 trip의 형태로 반환... 사용자에게 간단한 내용을 보여주고, 클릭 시 세부내용을 보여주는 형태로..?)
- myPlaceSearchAPI에 category를 MY_PLACE로 설정해서 프론트로 전송
- PlaceAPI에 Radius가 보이지 않도록 변경
## ✨ 변경 사항  
- 변경 사항 요약  

## 🙏 리뷰 요구사항  
- 리뷰어가 중점적으로 확인해야 할 부분  

## 📚 레퍼런스  
- 관련 문서 또는 참고한 내용  
