### PR TITLE
신규 API: 최근 추천 목록

### DIFF
--- a/src/main/java/com/travel/domain/place/api/RecommendedPlaceController.java
+++ b/src/main/java/com/travel/domain/place/api/RecommendedPlaceController.java
@@ -1,0 +1,45 @@
+package com.travel.domain.place.api;
+
+
+import com.travel.domain.place.dto.PlaceResponse;
+import com.travel.domain.place.dto.RecommendedPlaceResponse;
+import com.travel.domain.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/recommendedPlace")
+@RequiredArgsConstructor
+@Tag(name = "최근추천목록", description = "최근추천목록")
+public class RecommendedPlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping("/recent")
+    public ResponseEntity<List<RecommendedPlaceResponse>> getRecentRecommendedPlaces(
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<RecommendedPlaceResponse> result = placeService.getRecentRecommendedPlaces(size);
+        return ResponseEntity.ok(result);
+    }
+
+
+    @PostMapping("/saveRecommended")
+    public ResponseEntity<String> saveRecommendedTest(@RequestBody List<PlaceResponse> placeResponseList) {
+        try {
+            placeService.saveRecommendedPlaces(placeResponseList);
+            return ResponseEntity.ok("추천 장소 저장 완료");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("저장 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/travel/domain/place/dao/RecommendedPlaceRepository.java
+++ b/src/main/java/com/travel/domain/place/dao/RecommendedPlaceRepository.java
@@ -1,0 +1,18 @@
+package com.travel.domain.place.dao;
+
+import com.travel.domain.place.entity.RecommendedPlace;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import org.springframework.data.domain.Pageable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface RecommendedPlaceRepository extends JpaRepository<RecommendedPlace, Long> {
+
+
+    @Query("SELECT rp FROM RecommendedPlace rp ORDER BY rp.createdDate DESC")
+    List<RecommendedPlace> findTopRecent(Pageable pageable);
+}
+

--- a/src/main/java/com/travel/domain/place/dto/RecommendedPlaceResponse.java
+++ b/src/main/java/com/travel/domain/place/dto/RecommendedPlaceResponse.java
@@ -1,0 +1,48 @@
+package com.travel.domain.place.dto;
+
+import com.travel.domain.categories.entity.Category;
+import com.travel.domain.place.dto.PlaceDetailResponse;
+import com.travel.domain.placetype.entity.cafe.CafeTag;
+import com.travel.domain.placetype.entity.restaurant.RestaurantType;
+import com.travel.domain.placetype.entity.tourattraction.SubjectiveTag;
+import com.travel.domain.placetype.entity.tourattraction.TourattractionTag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class RecommendedPlaceResponse {
+
+    private Long id;
+    private String placeGoogleId;
+    private String name;
+    private String address;
+    private Category category;
+    private LocalDateTime recommendedAt;
+    private Double rating;
+
+    private List<CafeTag> cafeTags;
+    private RestaurantType restaurantType;
+    private List<TourattractionTag> tourattractionTags;
+    private List<SubjectiveTag> subjectiveTags;
+
+    public static RecommendedPlaceResponse from(PlaceDetailResponse detail, LocalDateTime recommendedAt) {
+        return RecommendedPlaceResponse.builder()
+                .id(detail.getId())
+                .placeGoogleId(detail.getPlaceGoogleId())
+                .name(detail.getName())
+                .address(detail.getAddress())
+                .category(detail.getCategory())
+                .recommendedAt(recommendedAt)
+                .rating(detail.getRating())
+                .cafeTags(detail.getCafeTags())
+                .restaurantType(detail.getRestaurantType())
+                .tourattractionTags(detail.getTourattractionTags())
+                .subjectiveTags(detail.getSubjectiveTags())
+                .build();
+    }
+
+}

--- a/src/main/java/com/travel/domain/place/entity/Place.java
+++ b/src/main/java/com/travel/domain/place/entity/Place.java
@@ -51,7 +51,7 @@ public class Place extends BaseTimeEntity {
     @Column(name = "phone_number", length = 100)
     private String phoneNumber;
 
-    @Column(name = "website", length = 100)
+    @Column(name = "website", length = 256)
     private String webSite;
 
     @Column(name = "opening_hours", length = 1000)

--- a/src/main/java/com/travel/domain/place/entity/RecommendedPlace.java
+++ b/src/main/java/com/travel/domain/place/entity/RecommendedPlace.java
@@ -1,0 +1,78 @@
+package com.travel.domain.place.entity;
+
+import com.travel.domain.categories.entity.Category;
+import com.travel.domain.place.dto.PlaceDetailResponse;
+import com.travel.domain.placetype.entity.cafe.CafeTag;
+import com.travel.domain.placetype.entity.restaurant.RestaurantType;
+import com.travel.domain.placetype.entity.tourattraction.SubjectiveTag;
+import com.travel.domain.placetype.entity.tourattraction.TourattractionTag;
+import com.travel.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Entity
+@Table(name = "recommended_place")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecommendedPlace extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String placeGoogleId;
+
+    private String name;
+
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private Double rating;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "recommended_place_cafe_tags", joinColumns = @JoinColumn(name = "recommended_place_id"))
+    @Enumerated(EnumType.STRING)
+    private List<CafeTag> cafeTags;
+
+    @Enumerated(EnumType.STRING)
+    private RestaurantType restaurantType;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "recommended_place_tour_tags", joinColumns = @JoinColumn(name = "recommended_place_id"))
+    @Enumerated(EnumType.STRING)
+    private List<TourattractionTag> tourattractionTags;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "recommended_place_subjective_tags", joinColumns = @JoinColumn(name = "recommended_place_id"))
+    @Enumerated(EnumType.STRING)
+    private List<SubjectiveTag> subjectiveTags;
+
+    private LocalDateTime recommendedAt;
+
+
+    public static RecommendedPlace from(PlaceDetailResponse detail) {
+        return RecommendedPlace.builder()
+                .placeGoogleId(detail.getPlaceGoogleId())
+                .name(detail.getName())
+                .address(detail.getAddress())
+                .category(detail.getCategory())
+                .rating(detail.getRating())
+                .cafeTags(detail.getCafeTags())
+                .restaurantType(detail.getRestaurantType())
+                .tourattractionTags(detail.getTourattractionTags())
+                .subjectiveTags(detail.getSubjectiveTags())
+                .recommendedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/travel/domain/place/service/PlaceService.java
+++ b/src/main/java/com/travel/domain/place/service/PlaceService.java
@@ -6,8 +6,10 @@ import com.travel.domain.datapipeline.google.dto.request.GoogleRequest;
 import com.travel.domain.datapipeline.google.dto.response.SavePlaceDto;
 import com.travel.domain.datapipeline.google.service.DatapipelineService;
 import com.travel.domain.place.dao.PlaceRepository;
+import com.travel.domain.place.dao.RecommendedPlaceRepository;
 import com.travel.domain.place.dto.*;
 import com.travel.domain.place.entity.Place;
+import com.travel.domain.place.entity.RecommendedPlace;
 import com.travel.domain.placetype.dao.cafe.CafeElasticsearchRepository;
 import com.travel.domain.placetype.dao.restaurant.RestaurantElasticsearchRepository;
 import com.travel.domain.placetype.dao.tourattraction.TourattractionElasticsearchRepository;
@@ -26,13 +28,12 @@ import com.travel.global.common.error.CustomException;
 import com.travel.global.common.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -48,6 +49,7 @@ public class PlaceService {
     private final CafeElasticsearchRepository cafeElasticsearchRepository;
     private final TourattractionElasticsearchRepository tourattractionElasticsearchRepository;
 
+    private final RecommendedPlaceRepository recommendedPlaceRepository;
     private final int PAGE_SIZE = 20;
 
 
@@ -70,6 +72,7 @@ public class PlaceService {
             placeResponseList.addAll(getTourattractionList(mainTourPlace, placeCoordinate, recommendationRequest.getTourattractionTagList(), recommendationRequest.getSubjectiveTagList()));
         }
 
+        saveRecommendedPlaces(placeResponseList);
 
         return PlaceListResponse.builder()
                 .placeResponseList(placeResponseList)
@@ -79,6 +82,20 @@ public class PlaceService {
 
     private PlaceCoordinate setMainPlaceValues(RecommendationRequest recommendationRequest){
         return placeGoogleService.getCoordinateByAddress(recommendationRequest.getMainTourPlace());
+    }
+    public void saveRecommendedPlaces(List<PlaceResponse> placeResponseList) {
+        List<PlaceResponse> shuffledList = new ArrayList<>(placeResponseList);
+        Collections.shuffle(shuffledList);
+
+        List<RecommendedPlace> toSave = shuffledList.stream()
+                .map(place -> {
+                    String placeGoogleId = place.getPlaceGoogleId();
+                    PlaceDetailResponse detail = getPlaceDetail(placeGoogleId);
+                    return RecommendedPlace.from(detail);
+                })
+                .toList();
+
+        recommendedPlaceRepository.saveAll(toSave);
     }
 
 
@@ -332,4 +349,17 @@ public class PlaceService {
                 .cafeTags(cafeDoc.getCafeTags())
                 .build();
     }
+
+    public List<RecommendedPlaceResponse> getRecentRecommendedPlaces(int size) {
+        List<RecommendedPlace> recent = recommendedPlaceRepository
+                .findTopRecent(PageRequest.of(0, size));
+
+        return recent.stream()
+                .map(rp -> {
+                    PlaceDetailResponse detail = getPlaceDetail(rp.getPlaceGoogleId());
+                    return RecommendedPlaceResponse.from(detail, rp.getCreatedDate());
+                })
+                .toList();
+    }
+
 }


### PR DESCRIPTION
MainPage에 띄울 목적...
searchRecommendation 호출 시 Return 직전에 검색되었던 값들을 셔플하여 시간과 함께 저장 get으로 최대 호출 갯수와 함께 요청 시 최신순으로 리턴

기존 코드 변경은 searchRecommendation 사이에 함수 하나 끼워넣은것과 place Column의 length 변경(오류발생해서)
검색 두번 되는 이슈는 따로 commit하지 않았습니다. 

🌱 관련 이슈  
close #155 

## 📌 작업 내용  
- 작업 1  
- 작업 2  

## ✨ 변경 사항  
- 변경 사항 요약  

## 🙏 리뷰 요구사항  
- 리뷰어가 중점적으로 확인해야 할 부분  

## 📚 레퍼런스  
- 관련 문서 또는 참고한 내용  
